### PR TITLE
Build for linux_amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-build: build_darwin_arm64 build_windows_386 build_windows_amd64
+build: build_darwin_arm64 build_windows_386 build_windows_amd64 build_linux_amd64
 
 build_darwin_arm64:
 	GOOS=darwin GOARCH=arm64 go build -trimpath -o pkg/civ2lint_darwin_arm64
@@ -9,3 +9,5 @@ build_windows_amd64:
 build_windows_386:
 	GOOS=windows GOARCH=386 go build -trimpath -o pkg/civ2lint_windows_386.exe
 
+build_linux_amd64:
+	GOOS=linux GOARCH=amd64 go build -trimpath -o pkg/civ2lint_linux_amd64


### PR DESCRIPTION
Works as-is on my system (ubuntu 24.04.1)
Only workaround needed was to explicitly rename RULES.TXT to rules.txt, because my filesystem is case-sensitive.

(I can try to tackle case-insensitive file search in a follow-up PR, maybe!)